### PR TITLE
WIP Node.js port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.kl
+./node_modules/*

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "shen-js-node",
+  "version": "0.0.1",
+  "author": "xkxx <xukexiang@gmail.com>",
+  "description": "Shen Node.js Port",
+  "dependencies" : {
+    "commander": "1.1.x"
+  }
+}

--- a/runtime-node/lib.js
+++ b/runtime-node/lib.js
@@ -1,0 +1,156 @@
+/*global shen_fail_obj, shenjs_error, shen_type_stream_in, shen_type_stream_out, shen_type_stream_inout, shenjs_globals*/
+
+var fs = require('fs');
+
+var DEBUG = false;
+
+if(DEBUG === true) {
+	var debug = console.debug;
+}
+else {
+	var debug = function() {};
+}
+
+var reqFuncs = {
+	buffer: '',
+	shenjs_open: function(type, name, direction) {
+		if (type[1] != "file")
+			return shen_fail_obj;
+		if (direction[1] == "in") {
+			try {
+				var fileObj = fs.readFileSync(name);
+			}
+			catch(e) {
+				shenjs_error(e);
+				return shen_fail_obj;
+			}
+			var index = 0;
+			var read_byte = function() {
+				if(index >= fileObj.byteLength()) {
+					return -1;
+				}
+				var byte = fileObj[index];
+				index++;
+				return byte;
+			};
+			var close_read = function() {
+				fileObj = null;
+			};
+		return [shen_type_stream_in, read_byte, close_read];
+		}
+		else if (direction[1] == "out") {
+			var stream = fs.createWriteStream(name);
+			var write_byte = function(byte) {
+				stream.write(new Buffer([byte]));
+			};
+			var close_write = function() {
+				stream.end();
+			};
+			return [shen_type_stream_out, write_byte, close_write];
+		}
+		shenjs_error("Unsupported open flags");
+		return shen_fail_obj;
+	},
+
+	shenjs_puts: function(str) {
+		//console.trace();
+		process.stdout.write(str.toString());
+	},
+	shenjs_gets: function() {
+		var ret = reqFuncs.buffer;
+		reqFuncs.buffer = '';
+		return ret;
+	},
+
+	shenjs_open_repl: function() {
+		var read_string = '', index = 0;
+		var repl_read_byte = function() {
+			if(index >= read_string.length) {
+				read_string = shenjs_gets();
+				if(read_string.length === 0) {
+					return -1;
+				}
+				index = 0;
+				return shenjs_call(shen_newline, []);
+			}
+			else {
+				var byte = read_string.charCodeAt(index);
+				//console.info('byte: ', byte, index);
+				index++;
+				return byte;
+			}
+		};
+		var repl_write_byte = function (byte) {
+			process.stdout.write(new Buffer([byte]));
+		};
+
+		var fout = [shen_type_stream_out, repl_write_byte, function(){}];
+
+		var fin = [shen_type_stream_in, repl_read_byte, function() {process.exit();}];
+
+		var finout = [shen_type_stream_inout, fin, fout];
+
+		shenjs_globals["shen_*stoutput*"] = fout;
+		shenjs_globals["shen_*stinput*"] = finout;
+	}
+};
+
+for (var i in reqFuncs) {
+	global[i] = reqFuncs[i];
+}
+
+function repl_line () {
+	var buffer = reqFuncs.buffer, bytes = [];
+	for (var i = buffer.length - 1; i >= 0; --i) {
+		bytes = [shen_type_cons, buffer.charCodeAt(i), bytes];
+	}
+	var tokens = shenjs_call(shenjs_repl_split_input, [bytes]);
+	if (tokens.length != 3 || tokens[0] != shen_tuple) {
+		return ['incomplete_input'];
+	}
+	try {
+		return [null, shenjs_call(shen_read_evaluate_print, [])];
+	}
+	catch (e) {
+		return [shenjs_error_to_string(e)];
+	}
+}
+
+function implode(list) {
+    var ret = "";
+    while (list.length == 3 && list[0] == shen_type_cons) {
+      ret += String.fromCharCode(list[1]);
+      list = list[2];
+    }
+    return ret;
+  }
+
+function is_empty(s) {
+    var n = s.length, i;
+    var space = " ".charCodeAt(0);
+    for (i = 0; i < n ; ++i)
+      if (s.charCodeAt(i) > space)
+        return false;
+    return true;
+  }
+
+function runtime_init() {
+	for (var i in reqFuncs) {
+		global[i] = reqFuncs[i];
+	}
+	shenjs_globals["shen_*implementation*"] = "html5";
+    shenjs_call(shenjs_open_repl, []);
+    shenjs_call(shen_credits, []);
+    shenjs_call(shen_initialise$_environment, []);
+}
+
+function displayPrompt() {
+	shenjs_call(shen_prompt, []);
+}
+
+function quit() {
+}
+
+// if this is not set, shen.js will attempt setting
+// up its repl and cause a bloody mess
+global.shenjs_external_repl = true;

--- a/shen-node.js
+++ b/shen-node.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+var repl = require('repl'),
+	vm = require('vm'),
+	fs = require('fs'),
+	program = require('commander');
+
+/*
+ * shen.js hacks
+ * because the current runtime is not CommomJS compatible,
+ * loading it via `require` will fail
+ * Also, because the js port is incapable of handling strings,
+ * we have to feed it via streams
+ */
+var shenJS = fs.readFileSync('./shen.js', 'utf-8');
+var shenLib = fs.readFileSync('./runtime-node/lib.js', 'utf-8');
+
+var shenVM = repl.REPLServer.prototype.createContext.call(null, {});
+vm.runInContext(shenLib, shenVM, './runtime-node/lib.js');
+
+console.info("Initializing Shen.js...");
+
+vm.runInContext(shenJS, shenVM, 'shen.js');
+vm.runInContext('runtime_init()', shenVM, 'runtime_init()');
+
+// --end of shen.js hacks
+
+program
+	.version('0.0.1')
+	.usage('[options] <file ...>')
+	.option('-c, --compile', 'Compile to JavaScript and save as .js files')
+	.option('-i, --interactive', 'Run an interactive Shen REPL')
+	.option('-p, --print', 'Print version information and exit')
+	.parse(process.argv);
+
+if(program.compile) {
+	compileShen(program.args, program.print);
+}
+else if(program.interactive) {
+	startRepl();
+}
+else if(program.args.length >= 1) {
+	runShen(program.args);
+}
+else {
+	startRepl();
+}
+
+function startRepl() {
+	var shenRepl = repl.start({
+		prompt: "",
+		input: process.stdin,
+		output: process.stdout,
+		ignoreUndefined: true,
+		eval: evalWrapper
+	});
+	shenRepl.context = shenVM;
+	vm.runInContext('displayPrompt();', shenVM, './runtime-node/lib.js');
+}
+
+function compileShen(file, print) {
+	console.info('Work In Progress');
+}
+
+function runShen(file) {
+	console.info('Work In Progress');
+}
+
+function evalWrapper(cmd, context, filename, callback) {
+	var ret = vm.runInContext('reqFuncs.buffer = decodeURI("' + encodeURI(cmd.slice(1,-1)) + '");repl_line()', shenVM, './runtime-node/lib.js');
+	if(ret[0] === null) {
+		callback(null); // Shen is better at displaying the results, so we won't interfere
+	}
+	else if(ret[0] === 'incomplete_input') {
+		callback('SyntaxError'); // will show ... prompt
+	}
+	else {
+		callback(ret[0]);
+	}
+}
+
+// shen.js demands using its own prompt
+repl.REPLServer.prototype.displayPrompt = function() {
+		if (this.bufferedCommand.length) {
+			process.stdout.write('...');
+		}
+		else {
+			vm.runInContext('displayPrompt();', shenVM, './runtime-node/lib.js');
+		}
+	};


### PR DESCRIPTION
Hi Gravicappa,

This is a work in progress node.js port of Shen.
##### The following files are added:
- `shen-node.js` program entry
- `runtime-node/lib.js` runtime functions and hacks
- `package.json` required package file
##### The following file is changed:
- `.gitignore`: ignore `node_modules` directory
##### How to test:
- Clone the repo
- Install node.js on your platform. Make sure you can use `npm` and `node` commands
- `npm install`
- `./shen-node.js` or `node shen-node.js`
##### Bugs
- Sometimes entering a partially completed expression will cause endless recursive calls. This is caused by shen.js keeping calling `repl_read_byte` despite getting -1 responses. I think it's a problem with the shen.js file. To test this bug, type `(str [enter]` in the repl.
- Transpile/execute shen.js do not work. I haven't figured out how they work in shen.js yet.

Please test out the code and report any problems so I can fix them.

Regards,
xkxx
